### PR TITLE
Fix: missing footnotes and other extensions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,4 +8,5 @@
                  [com.vladsch.flexmark/flexmark "0.60.2"]
                  [com.vladsch.flexmark/flexmark-util "0.60.2"]
                  [com.vladsch.flexmark/flexmark-ext-footnotes "0.60.2"]
+                 [com.vladsch.flexmark/flexmark-ext-superscript "0.60.2"]
                  [com.vladsch.flexmark/flexmark-ext-tables "0.60.2"]])

--- a/project.clj
+++ b/project.clj
@@ -8,5 +8,6 @@
                  [com.vladsch.flexmark/flexmark "0.60.2"]
                  [com.vladsch.flexmark/flexmark-util "0.60.2"]
                  [com.vladsch.flexmark/flexmark-ext-footnotes "0.60.2"]
+                 [com.vladsch.flexmark/flexmark-ext-gfm-strikethrough "0.60.2"]
                  [com.vladsch.flexmark/flexmark-ext-superscript "0.60.2"]
                  [com.vladsch.flexmark/flexmark-ext-tables "0.60.2"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cryogen-flexmark "0.1.0"
+(defproject cryogen-flexmark "0.1.1"
   :description "Markdown parser for Cryogen"
   :url "https://github.com/cryogen-project/cryogen-flexmark"
   :license {:name "BSD 2"

--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,5 @@
                  [cryogen-core "0.3.1"]
                  [com.vladsch.flexmark/flexmark "0.60.2"]
                  [com.vladsch.flexmark/flexmark-util "0.60.2"]
-                 [com.vladsch.flexmark/flexmark-ext-footnotes "0.60.2"]])
+                 [com.vladsch.flexmark/flexmark-ext-footnotes "0.60.2"]
+                 [com.vladsch.flexmark/flexmark-ext-tables "0.60.2"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cryogen-flexmark "0.1.1"
+(defproject cryogen-flexmark "0.1.2"
   :description "Markdown parser for Cryogen"
   :url "https://github.com/cryogen-project/cryogen-flexmark"
   :license {:name "BSD 2"

--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,6 @@
             :url "https://opensource.org/licenses/BSD-2-Clause"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [cryogen-core "0.3.1"]
-                 [com.vladsch.flexmark/flexmark "0.12.3"]])
+                 [com.vladsch.flexmark/flexmark "0.60.2"]
+                 [com.vladsch.flexmark/flexmark-util "0.60.2"]
+                 [com.vladsch.flexmark/flexmark-ext-footnotes "0.60.2"]])

--- a/src/cryogen_flexmark/core.clj
+++ b/src/cryogen_flexmark/core.clj
@@ -4,13 +4,16 @@
   (:import cryogen_core.markup.Markup
            com.vladsch.flexmark.parser.Parser
            com.vladsch.flexmark.html.HtmlRenderer
-           com.vladsch.flexmark.Extension))
+           (com.vladsch.flexmark.util.options MutableDataSet)))
 
 (defn markdown
   "Returns a Markdown (CommonMark) implementation of the Markup protocol."
   []
-  (let [parser (.build (Parser/builder))
-        renderer (.build (HtmlRenderer/builder))]
+  (let [options (-> (MutableDataSet.)
+                    (.set HtmlRenderer/GENERATE_HEADER_ID true)
+                    (.set HtmlRenderer/RENDER_HEADER_ID true))
+        parser (.build (Parser/builder options))
+        renderer (.build (HtmlRenderer/builder options))]
    (reify Markup
     (dir [this] "md")
     (ext [this] ".md")

--- a/src/cryogen_flexmark/core.clj
+++ b/src/cryogen_flexmark/core.clj
@@ -6,6 +6,7 @@
            com.vladsch.flexmark.html.HtmlRenderer
            (com.vladsch.flexmark.util.data MutableDataSet)
            (com.vladsch.flexmark.ext.footnotes FootnoteExtension)
+           (com.vladsch.flexmark.ext.superscript SuperscriptExtension)
            (com.vladsch.flexmark.ext.tables TablesExtension)
            (java.util ArrayList)))
 
@@ -13,6 +14,7 @@
   "Returns a Markdown (CommonMark) implementation of the Markup protocol."
   []
   (let [extensions [(FootnoteExtension/create)
+                    (SuperscriptExtension/create)
                     (TablesExtension/create)]
         options (-> (MutableDataSet.)
                     (.set Parser/EXTENSIONS (ArrayList. extensions))

--- a/src/cryogen_flexmark/core.clj
+++ b/src/cryogen_flexmark/core.clj
@@ -6,6 +6,7 @@
            com.vladsch.flexmark.html.HtmlRenderer
            (com.vladsch.flexmark.util.data MutableDataSet)
            (com.vladsch.flexmark.ext.footnotes FootnoteExtension)
+           (com.vladsch.flexmark.ext.gfm.strikethrough StrikethroughExtension)
            (com.vladsch.flexmark.ext.superscript SuperscriptExtension)
            (com.vladsch.flexmark.ext.tables TablesExtension)
            (java.util ArrayList)))
@@ -14,6 +15,7 @@
   "Returns a Markdown (CommonMark) implementation of the Markup protocol."
   []
   (let [extensions [(FootnoteExtension/create)
+                    (StrikethroughExtension/create)
                     (SuperscriptExtension/create)
                     (TablesExtension/create)]
         options (-> (MutableDataSet.)

--- a/src/cryogen_flexmark/core.clj
+++ b/src/cryogen_flexmark/core.clj
@@ -16,6 +16,7 @@
                     (TablesExtension/create)]
         options (-> (MutableDataSet.)
                     (.set Parser/EXTENSIONS (ArrayList. extensions))
+                    (.set HtmlRenderer/FENCED_CODE_LANGUAGE_CLASS_PREFIX "")
                     (.set HtmlRenderer/GENERATE_HEADER_ID true)
                     (.set HtmlRenderer/RENDER_HEADER_ID true))
         parser (.build (Parser/builder options))

--- a/src/cryogen_flexmark/core.clj
+++ b/src/cryogen_flexmark/core.clj
@@ -4,12 +4,16 @@
   (:import cryogen_core.markup.Markup
            com.vladsch.flexmark.parser.Parser
            com.vladsch.flexmark.html.HtmlRenderer
-           (com.vladsch.flexmark.util.options MutableDataSet)))
+           (com.vladsch.flexmark.util.data MutableDataSet)
+           (com.vladsch.flexmark.ext.footnotes FootnoteExtension)
+           (java.util ArrayList)))
 
 (defn markdown
   "Returns a Markdown (CommonMark) implementation of the Markup protocol."
   []
-  (let [options (-> (MutableDataSet.)
+  (let [extensions [(FootnoteExtension/create)]
+        options (-> (MutableDataSet.)
+                    (.set Parser/EXTENSIONS (ArrayList. extensions))
                     (.set HtmlRenderer/GENERATE_HEADER_ID true)
                     (.set HtmlRenderer/RENDER_HEADER_ID true))
         parser (.build (Parser/builder options))

--- a/src/cryogen_flexmark/core.clj
+++ b/src/cryogen_flexmark/core.clj
@@ -6,12 +6,14 @@
            com.vladsch.flexmark.html.HtmlRenderer
            (com.vladsch.flexmark.util.data MutableDataSet)
            (com.vladsch.flexmark.ext.footnotes FootnoteExtension)
+           (com.vladsch.flexmark.ext.tables TablesExtension)
            (java.util ArrayList)))
 
 (defn markdown
   "Returns a Markdown (CommonMark) implementation of the Markup protocol."
   []
-  (let [extensions [(FootnoteExtension/create)]
+  (let [extensions [(FootnoteExtension/create)
+                    (TablesExtension/create)]
         options (-> (MutableDataSet.)
                     (.set Parser/EXTENSIONS (ArrayList. extensions))
                     (.set HtmlRenderer/GENERATE_HEADER_ID true)


### PR DESCRIPTION
Based on #2 - merge that PR first.

Potentially controversial fixes fenced off in a separate PR - I updated the main dependency _a lot_ because I didn't want to hunt ~50 minor versions back for old options and plugins.

- Added extension `flexmark-ext-footnotes` fixes #3 (missing footnote links)
- Added extension `flexmark-ext-tables`, fixes tables no longer rendering
- Added extension `flexmark-ext-gfm-strikethrough`, strikethrough
- Added extension `flexmark-ext-superscript` - superscript _not backwards compatible!_
- Reset `HtmlRenderer/FENCED_CODE_LANGUAGE_CLASS_PREFIX` - could break Klipse integration and custom CSS

Re: language class prefix - if you provide a language string in triple-tick fenced code, Flexmark by default prefixes it with `language-` which the previous dependency didn't use to do. If the user expected specific classes in their old config (css, Klipse, anything else), the old config will stop working. (`hljs` is fine, however.)
