### PR TITLE
Allow multiple extensions in  Markup.

### DIFF
--- a/.lein-failures
+++ b/.lein-failures
@@ -1,0 +1,1 @@
+{"cryogen-flexmark.core-test" ["a-test"]}

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject cryogen-flexmark "0.1.2"
+(defproject cryogen-flexmark "0.1.3"
   :description "Markdown parser for Cryogen"
   :url "https://github.com/cryogen-project/cryogen-flexmark"
   :license {:name "BSD 2"
             :url "https://opensource.org/licenses/BSD-2-Clause"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [cryogen-core "0.3.1"]
+                 [cryogen-core "0.3.2"]
                  [com.vladsch.flexmark/flexmark "0.60.2"]
                  [com.vladsch.flexmark/flexmark-util "0.60.2"]
                  [com.vladsch.flexmark/flexmark-ext-footnotes "0.60.2"]

--- a/src/cryogen_flexmark/core.clj
+++ b/src/cryogen_flexmark/core.clj
@@ -27,7 +27,7 @@
         renderer (.build (HtmlRenderer/builder options))]
    (reify Markup
     (dir [this] "md")
-    (ext [this] ".md")
+    (exts [this] #{".md"})
     (render-fn [this]
       (fn [rdr config]
         (->> (java.io.BufferedReader. rdr)


### PR DESCRIPTION
Addresses Issue Number 6 in the `cryogen-asciidoc` repo.
For the set of related PRs see the main PR on the `cryogen-core` repo.