### PR TITLE
Add the AttributesExtensions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
                  [cryogen-core "0.3.2"]
                  [com.vladsch.flexmark/flexmark "0.60.2"]
                  [com.vladsch.flexmark/flexmark-util "0.60.2"]
+                 [com.vladsch.flexmark/flexmark-ext-attributes "0.60.2"]
                  [com.vladsch.flexmark/flexmark-ext-footnotes "0.60.2"]
                  [com.vladsch.flexmark/flexmark-ext-gfm-strikethrough "0.60.2"]
                  [com.vladsch.flexmark/flexmark-ext-superscript "0.60.2"]

--- a/src/cryogen_flexmark/core.clj
+++ b/src/cryogen_flexmark/core.clj
@@ -5,6 +5,7 @@
            com.vladsch.flexmark.parser.Parser
            com.vladsch.flexmark.html.HtmlRenderer
            (com.vladsch.flexmark.util.data MutableDataSet)
+           (com.vladsch.flexmark.ext.attributes AttributesExtension)
            (com.vladsch.flexmark.ext.footnotes FootnoteExtension)
            (com.vladsch.flexmark.ext.gfm.strikethrough StrikethroughExtension)
            (com.vladsch.flexmark.ext.superscript SuperscriptExtension)
@@ -17,7 +18,8 @@
   (let [extensions [(FootnoteExtension/create)
                     (StrikethroughExtension/create)
                     (SuperscriptExtension/create)
-                    (TablesExtension/create)]
+                    (TablesExtension/create)
+                    (AttributesExtension/create)]
         options (-> (MutableDataSet.)
                     (.set Parser/EXTENSIONS (ArrayList. extensions))
                     (.set HtmlRenderer/FENCED_CODE_LANGUAGE_CLASS_PREFIX "")


### PR DESCRIPTION
so that we can specify classes etc for the HTML elements to be rendered
(and thus replace the use of HTML with md in cryogen-docs).

See https://github.com/vsch/flexmark-java/wiki/Attributes-Extension